### PR TITLE
added sort by date

### DIFF
--- a/src/components/ChevronSvg.tsx
+++ b/src/components/ChevronSvg.tsx
@@ -1,0 +1,22 @@
+import { FC } from "react";
+
+export const ChevronSvg: FC<{ className: string; onClick: () => void }> = ({
+  className,
+  onClick,
+}) => (
+  <svg
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    onClick={onClick}
+  >
+    <path
+      d="M33 33L50 50L67 33"
+      stroke="#95959f"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={10}
+    />
+  </svg>
+);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Head from "next/head";
 import Image from "next/image";
 import { Space_Mono, Roboto } from "next/font/google";
@@ -8,8 +9,10 @@ import { ExchangesType, HomeProps } from "../types";
 
 import { ArrowSvg } from "@/components/ArrowSvg";
 import { CryptoText } from "@/components/CryptoText";
+import { ChevronSvg } from "@/components/ChevronSvg";
 
 import { getLocalData } from "../lib/localData";
+import { orderFunction } from "@/utils/utils";
 
 const space_mono = Space_Mono({
   variable: "--font-space-mono",
@@ -35,6 +38,10 @@ export async function getStaticProps() {
 }
 
 export default function Home({ exchanges }: HomeProps) {
+  const [order, setOrder] = useState<"asc" | "desc">("desc");
+
+  const orderedExchanges = exchanges.sort(orderFunction(order));
+
   return (
     <>
       <Head>
@@ -85,8 +92,14 @@ export default function Home({ exchanges }: HomeProps) {
             <span className="text-xs col-span-3 text-[#95959f] hidden lg:block">
               Documentos
             </span>
-            <span className="text-xs col-span-2 text-[#95959f] hidden lg:block">
-              Actualización
+            <span className="text-xs col-span-2 text-[#95959f] hidden lg:flex lg:gap-1 lg:items-center">
+              Actualizado
+              <ChevronSvg
+                className={`w-5 flex-shrink-0 flex items-center cursor-pointer ${
+                  order === "asc" && "rotate-180"
+                }`}
+                onClick={() => setOrder(order === "asc" ? "desc" : "asc")}
+              />
             </span>
             <span className="text-xs col-span-4 text-[#95959f] hidden lg:block">
               Estado
@@ -94,7 +107,7 @@ export default function Home({ exchanges }: HomeProps) {
           </div>
 
           <div className="font-roboto">
-            {exchanges.map((exchange, index) => (
+            {orderedExchanges.map((exchange, index) => (
               <div
                 key={index}
                 className={` grid grid-cols-1 lg:grid-cols-12 gap-4 lg:gap-8 border-b border-[#333333] pt-6 first-of-type:border-y first-of-type:pt-3 pb-6 lg:py-3 items-center text-[#CECECE] lg:hover:bg-[#111] hover:text-white transition-colors`}
@@ -140,14 +153,14 @@ export default function Home({ exchanges }: HomeProps) {
                   }`}
                 >
                   <span className="col-span-3 text-xs text-[#95959f] font-mono block lg:hidden mb-2">
-                    Última actualización
+                    Actualizado
                   </span>
                   {exchange.last_update ? exchange.last_update : "-"}
                 </span>
 
                 <span className="lg:col-span-4 text-[#95959f]">
                   <span className="col-span-3 text-xs text-[#95959f] font-mono block lg:hidden mb-2">
-                    Notas
+                    Estado
                   </span>
                   {exchange.notes ? (
                     exchange.notes.url ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { StaticImageData } from 'next/image';
 
-export type ExchangesType = Array<{
+export type ExchangeType = {
     name: string;
     iconPath: StaticImageData;
     url: string;
@@ -13,7 +13,9 @@ export type ExchangesType = Array<{
         text: string;
         url?: string;
     };
-}>;
+}
+
+export type ExchangesType = Array<ExchangeType>;
 
 export type HomeProps = {
     exchanges: ExchangesType;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,68 @@
+import { ExchangeType } from "@/types";
+
 export const generateRandomString = (length: number): string =>
   Math.random()
     .toString(36)
     .substring(2, length + 2);
+
+
+export function orderFunction(order: "asc" | "desc") {
+  return function(a: ExchangeType, b: ExchangeType): number {
+    const aHasUpdate = a.hasOwnProperty("last_update");
+    const bHasUpdate = b.hasOwnProperty("last_update");
+
+    if (!aHasUpdate && !bHasUpdate) {
+      return 0;
+    } else if (!aHasUpdate) {
+      return order === "asc" ? -1 : 1; // Undefined goes first in "asc" order
+    } else if (!bHasUpdate) {
+      return order === "asc" ? 1 : -1; // Undefined goes first in "asc" order
+    } else if (order === "asc") {
+      if (!isDate(a.last_update) && !isDate(b.last_update)) {
+        return compareStrings(a.last_update, b.last_update); // Compare strings, accounting for undefined values
+      } else if (!isDate(a.last_update)) {
+        return 1; // Non-date strings go after dates in "asc" order
+      } else if (!isDate(b.last_update)) {
+        return -1; // Non-date strings go after dates in "asc" order
+      } else {
+        const aDate = getDateValue(a.last_update);
+        const bDate = getDateValue(b.last_update);
+
+        return aDate - bDate; // Compare dates
+      }
+    } else {
+      if (!isDate(a.last_update) && !isDate(b.last_update)) {
+        return compareStrings(b.last_update, a.last_update); // Compare strings, accounting for undefined values
+      } else if (!isDate(a.last_update)) {
+        return -1; // Non-date strings go before dates in "desc" order
+      } else if (!isDate(b.last_update)) {
+        return 1; // Non-date strings go before dates in "desc" order
+      } else {
+        const aDate = getDateValue(a.last_update);
+        const bDate = getDateValue(b.last_update);
+
+        return bDate - aDate; // Compare dates
+      }
+    }
+  };
+}
+
+function isDate(value: string | undefined): boolean {
+  return value !== undefined && !isNaN(Date.parse(value));
+}
+
+function getDateValue(value: string | undefined): number {
+  return value !== undefined ? new Date(value).getTime() : 0;
+}
+
+function compareStrings(a: string | undefined, b: string | undefined): number {
+  if (a === undefined && b === undefined) {
+    return 0;
+  } else if (a === undefined) {
+    return -1;
+  } else if (b === undefined) {
+    return 1;
+  }
+
+  return a.localeCompare(b);
+}


### PR DESCRIPTION
Se añade la posibilidad de ordenar por fecha de actualización la lista. 

En orden descendente: exchanges que tienen un string como última fecha de actualización (caso lemon con "Realtime"), después todos los exchanges que tienen una fecha de actualización en orden descendente (primero hoy, siguiente ayer, siguiente anteayer), por último exchanges que no tienen fecha de actualización.

El orden ascendente es exactamente lo opuesto.